### PR TITLE
Add nil check on total image size calculation

### DIFF
--- a/api/registry.go
+++ b/api/registry.go
@@ -156,7 +156,9 @@ func (reg *registryApi) loadMetaData(repo Repo) *Response {
 	resp.Repo.Count = len(resp.Layers)
 
 	for _, layer := range resp.Layers {
-		totalSize += layer.Size
+		if layer != nil {
+			totalSize += layer.Size
+		}
 	}
 
 	resp.Repo.Size = totalSize


### PR DESCRIPTION
@argvader The other error handling that you're doing may address this already, but when I was slamming images at the API yesterday, this is the spot where it would blow up on me.

If the retrieval of a particular image layer were to fail we'd end-up with an empty slot in the array of layer metadata. Then, when iterating over the layers to calculate the total image size, there would be a fatal _memory dereference_ error when trying to call `.Size` on a nil value.

This code change will prevent the app from crashing in this scenario.
