### PR TITLE
Enable graceful shutdown

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -36,6 +36,15 @@
 		{
 			"ImportPath": "github.com/stretchr/testify/mock",
 			"Rev": "efa3c4c36479edac5af79cbcb4bc8cb525e09b13"
+		},
+		{
+			"ImportPath": "golang.org/x/net/netutil",
+			"Rev": "e0403b4e005737430c05a57aac078479844f919c"
+		},
+		{
+			"ImportPath": "gopkg.in/tylerb/graceful.v1",
+			"Comment": "v1",
+			"Rev": "d506b859c378b0e4a1b16d44021f3937f9ba4578"
 		}
 	]
 }

--- a/Godeps/_workspace/src/golang.org/x/net/netutil/listen.go
+++ b/Godeps/_workspace/src/golang.org/x/net/netutil/listen.go
@@ -1,0 +1,48 @@
+// Copyright 2013 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package netutil provides network utility functions, complementing the more
+// common ones in the net package.
+package netutil
+
+import (
+	"net"
+	"sync"
+)
+
+// LimitListener returns a Listener that accepts at most n simultaneous
+// connections from the provided Listener.
+func LimitListener(l net.Listener, n int) net.Listener {
+	return &limitListener{l, make(chan struct{}, n)}
+}
+
+type limitListener struct {
+	net.Listener
+	sem chan struct{}
+}
+
+func (l *limitListener) acquire() { l.sem <- struct{}{} }
+func (l *limitListener) release() { <-l.sem }
+
+func (l *limitListener) Accept() (net.Conn, error) {
+	l.acquire()
+	c, err := l.Listener.Accept()
+	if err != nil {
+		l.release()
+		return nil, err
+	}
+	return &limitListenerConn{Conn: c, release: l.release}, nil
+}
+
+type limitListenerConn struct {
+	net.Conn
+	releaseOnce sync.Once
+	release     func()
+}
+
+func (l *limitListenerConn) Close() error {
+	err := l.Conn.Close()
+	l.releaseOnce.Do(l.release)
+	return err
+}

--- a/Godeps/_workspace/src/golang.org/x/net/netutil/listen_test.go
+++ b/Godeps/_workspace/src/golang.org/x/net/netutil/listen_test.go
@@ -1,0 +1,103 @@
+// Copyright 2013 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.3
+
+// (We only run this test on Go 1.3 because the HTTP client timeout behavior
+// was bad in previous releases, causing occasional deadlocks.)
+
+package netutil
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestLimitListener(t *testing.T) {
+	const (
+		max = 5
+		num = 200
+	)
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer l.Close()
+	l = LimitListener(l, max)
+
+	var open int32
+	go http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if n := atomic.AddInt32(&open, 1); n > max {
+			t.Errorf("%d open connections, want <= %d", n, max)
+		}
+		defer atomic.AddInt32(&open, -1)
+		time.Sleep(10 * time.Millisecond)
+		fmt.Fprint(w, "some body")
+	}))
+
+	var wg sync.WaitGroup
+	var failed int32
+	for i := 0; i < num; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c := http.Client{Timeout: 3 * time.Second}
+			r, err := c.Get("http://" + l.Addr().String())
+			if err != nil {
+				t.Logf("Get: %v", err)
+				atomic.AddInt32(&failed, 1)
+				return
+			}
+			defer r.Body.Close()
+			io.Copy(ioutil.Discard, r.Body)
+		}()
+	}
+	wg.Wait()
+
+	// We expect some Gets to fail as the kernel's accept queue is filled,
+	// but most should succeed.
+	if failed >= num/2 {
+		t.Errorf("too many Gets failed: %v", failed)
+	}
+}
+
+type errorListener struct {
+	net.Listener
+}
+
+func (errorListener) Accept() (net.Conn, error) {
+	return nil, errFake
+}
+
+var errFake = errors.New("fake error from errorListener")
+
+// This used to hang.
+func TestLimitListenerError(t *testing.T) {
+	donec := make(chan bool, 1)
+	go func() {
+		const n = 2
+		ll := LimitListener(errorListener{}, n)
+		for i := 0; i < n+1; i++ {
+			_, err := ll.Accept()
+			if err != errFake {
+				t.Fatalf("Accept error = %v; want errFake", err)
+			}
+		}
+		donec <- true
+	}()
+	select {
+	case <-donec:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout. deadlock?")
+	}
+}

--- a/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/.gitignore
+++ b/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/.gitignore
@@ -1,0 +1,23 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test

--- a/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/LICENSE
+++ b/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Tyler Bunnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/README.md
+++ b/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/README.md
@@ -1,0 +1,137 @@
+graceful [![GoDoc](https://godoc.org/github.com/tylerb/graceful?status.png)](http://godoc.org/github.com/tylerb/graceful) [![wercker status](https://app.wercker.com/status/2729ba763abf87695a17547e0f7af4a4/s "wercker status")](https://app.wercker.com/project/bykey/2729ba763abf87695a17547e0f7af4a4)
+========
+
+Graceful is a Go 1.3+ package enabling graceful shutdown of http.Handler servers.
+
+## Installation
+
+To install, simply execute:
+
+```
+go get gopkg.in/tylerb/graceful.v1
+```
+
+I am using [gopkg.in](http://http://labix.org/gopkg.in) to control releases.
+
+## Usage
+
+Using Graceful is esay. Simply create your http.Handler and pass it to the `Run` function:
+
+```go
+package main
+
+import (
+  "github.com/tylerb/graceful"
+  "net/http"
+  "fmt"
+  "time"
+)
+
+func main() {
+  mux := http.NewServeMux()
+  mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+    fmt.Fprintf(w, "Welcome to the home page!")
+  })
+
+  graceful.Run(":3001",10*time.Second,mux)
+}
+```
+
+Another example, using [Negroni](https://github.com/codegangsta/negroni), functions in much the same manner:
+
+```go
+package main
+
+import (
+  "github.com/codegangsta/negroni"
+  "github.com/tylerb/graceful"
+  "net/http"
+  "fmt"
+  "time"
+)
+
+func main() {
+  mux := http.NewServeMux()
+  mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+    fmt.Fprintf(w, "Welcome to the home page!")
+  })
+
+  n := negroni.Classic()
+  n.UseHandler(mux)
+  //n.Run(":3000")
+  graceful.Run(":3001",10*time.Second,n)
+}
+```
+
+In addition to Run there are the http.Server counterparts ListenAndServe, ListenAndServeTLS and Serve, which allow you to configure HTTPS, custom timeouts and error handling.
+Graceful may also be used by instantiating its Server type directly, which embeds an http.Server:
+
+```go
+mux := // ...
+
+srv := &graceful.Server{
+  Timeout: 10 * time.Second,
+
+  Server: &http.Server{
+    Addr: ":1234",
+    Handler: mux,
+  },
+}
+
+srv.ListenAndServe()
+```
+
+This form allows you to set the ConnState callback, which works in the same way as in http.Server:
+
+```go
+mux := // ...
+
+srv := &graceful.Server{
+  Timeout: 10 * time.Second,
+
+  ConnState: func(conn net.Conn, state http.ConnState) {
+    // conn has a new state
+  },
+
+  Server: &http.Server{
+    Addr: ":1234",
+    Handler: mux,
+  },
+}
+
+srv.ListenAndServe()
+```
+
+## Behaviour
+
+When Graceful is sent a SIGINT or SIGTERM (possibly from ^C or a kill command), it:
+
+1. Disables keepalive connections.
+2. Closes the listening socket, allowing another process to listen on that port immediately.
+3. Starts a timer of `timeout` duration to give active requests a chance to finish.
+4. When timeout expires, closes all active connections.
+5. Closes the `stopChan`, waking up any blocking goroutines.
+6. Returns from the function, allowing the server to terminate.
+
+## Notes
+
+If the `timeout` argument to `Run` is 0, the server never times out, allowing all active requests to complete.
+
+If you wish to stop the server in some way other than an OS signal, you may call the `Stop()` function.
+This function stops the server, gracefully, using the new timeout value you provide. The `StopChan()` function
+returns a channel on which you can block while waiting for the server to stop. This channel will be closed when
+the server is stopped, allowing your execution to proceed. Multiple goroutines can block on this channel at the
+same time and all will be signalled when stopping is complete.
+
+## Contributing
+
+If you would like to contribute, please:
+
+1. Create a GitHub issue regarding the contribution. Features and bugs should be discussed beforehand.
+2. Fork the repository.
+3. Create a pull request with your solution. This pull request should reference and close the issues (Fix #2).
+
+All pull requests should:
+
+1. Pass [gometalinter -t .](https://github.com/alecthomas/gometalinter) with no warnings.
+2. Be `go fmt` formatted.

--- a/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/graceful.go
+++ b/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/graceful.go
@@ -1,0 +1,300 @@
+package graceful
+
+import (
+	"crypto/tls"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/net/netutil"
+)
+
+// Server wraps an http.Server with graceful connection handling.
+// It may be used directly in the same way as http.Server, or may
+// be constructed with the global functions in this package.
+//
+// Example:
+//	srv := &graceful.Server{
+//		Timeout: 5 * time.Second,
+//		Server: &http.Server{Addr: ":1234", Handler: handler},
+//	}
+//	srv.ListenAndServe()
+type Server struct {
+	*http.Server
+
+	// Timeout is the duration to allow outstanding requests to survive
+	// before forcefully terminating them.
+	Timeout time.Duration
+
+	// Limit the number of outstanding requests
+	ListenLimit int
+
+	// ConnState specifies an optional callback function that is
+	// called when a client connection changes state. This is a proxy
+	// to the underlying http.Server's ConnState, and the original
+	// must not be set directly.
+	ConnState func(net.Conn, http.ConnState)
+
+	// ShutdownInitiated is an optional callback function that is called
+	// when shutdown is initiated. It can be used to notify the client
+	// side of long lived connections (e.g. websockets) to reconnect.
+	ShutdownInitiated func()
+
+	// NoSignalHandling prevents graceful from automatically shutting down
+	// on SIGINT and SIGTERM. If set to true, you must shut down the server
+	// manually with Stop().
+	NoSignalHandling bool
+
+	// interrupt signals the listener to stop serving connections,
+	// and the server to shut down.
+	interrupt chan os.Signal
+
+	// stopChan is the channel on which callers may block while waiting for
+	// the server to stop.
+	stopChan chan struct{}
+
+	// stopLock is used to protect access to the stopChan.
+	stopLock sync.RWMutex
+
+	// connections holds all connections managed by graceful
+	connections map[net.Conn]struct{}
+}
+
+// Run serves the http.Handler with graceful shutdown enabled.
+//
+// timeout is the duration to wait until killing active requests and stopping the server.
+// If timeout is 0, the server never times out. It waits for all active requests to finish.
+func Run(addr string, timeout time.Duration, n http.Handler) {
+	srv := &Server{
+		Timeout: timeout,
+		Server:  &http.Server{Addr: addr, Handler: n},
+	}
+
+	if err := srv.ListenAndServe(); err != nil {
+		if opErr, ok := err.(*net.OpError); !ok || (ok && opErr.Op != "accept") {
+			logger := log.New(os.Stdout, "[graceful] ", 0)
+			logger.Fatal(err)
+		}
+	}
+}
+
+// ListenAndServe is equivalent to http.Server.ListenAndServe with graceful shutdown enabled.
+//
+// timeout is the duration to wait until killing active requests and stopping the server.
+// If timeout is 0, the server never times out. It waits for all active requests to finish.
+func ListenAndServe(server *http.Server, timeout time.Duration) error {
+	srv := &Server{Timeout: timeout, Server: server}
+	return srv.ListenAndServe()
+}
+
+// ListenAndServe is equivalent to http.Server.ListenAndServe with graceful shutdown enabled.
+func (srv *Server) ListenAndServe() error {
+	// Create the listener so we can control their lifetime
+	addr := srv.Addr
+	if addr == "" {
+		addr = ":http"
+	}
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	if srv.ListenLimit != 0 {
+		l = netutil.LimitListener(l, srv.ListenLimit)
+	}
+	return srv.Serve(l)
+}
+
+// ListenAndServeTLS is equivalent to http.Server.ListenAndServeTLS with graceful shutdown enabled.
+//
+// timeout is the duration to wait until killing active requests and stopping the server.
+// If timeout is 0, the server never times out. It waits for all active requests to finish.
+func ListenAndServeTLS(server *http.Server, certFile, keyFile string, timeout time.Duration) error {
+	srv := &Server{Timeout: timeout, Server: server}
+	return srv.ListenAndServeTLS(certFile, keyFile)
+}
+
+// ListenAndServeTLS is equivalent to http.Server.ListenAndServeTLS with graceful shutdown enabled.
+func (srv *Server) ListenAndServeTLS(certFile, keyFile string) error {
+	// Create the listener ourselves so we can control its lifetime
+	addr := srv.Addr
+	if addr == "" {
+		addr = ":https"
+	}
+
+	config := &tls.Config{}
+	if srv.TLSConfig != nil {
+		*config = *srv.TLSConfig
+	}
+	if config.NextProtos == nil {
+		config.NextProtos = []string{"http/1.1"}
+	}
+
+	var err error
+	config.Certificates = make([]tls.Certificate, 1)
+	config.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+
+	conn, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	tlsListener := tls.NewListener(conn, config)
+	return srv.Serve(tlsListener)
+}
+
+// Serve is equivalent to http.Server.Serve with graceful shutdown enabled.
+//
+// timeout is the duration to wait until killing active requests and stopping the server.
+// If timeout is 0, the server never times out. It waits for all active requests to finish.
+func Serve(server *http.Server, l net.Listener, timeout time.Duration) error {
+	srv := &Server{Timeout: timeout, Server: server}
+	return srv.Serve(l)
+}
+
+// Serve is equivalent to http.Server.Serve with graceful shutdown enabled.
+func (srv *Server) Serve(listener net.Listener) error {
+	// Track connection state
+	add := make(chan net.Conn)
+	remove := make(chan net.Conn)
+
+	var timesLock sync.Mutex
+	times := map[net.Conn]time.Time{}
+
+	srv.Server.ConnState = func(conn net.Conn, state http.ConnState) {
+		switch state {
+		case http.StateNew:
+			timesLock.Lock()
+			times[conn] = time.Now()
+			timesLock.Unlock()
+			add <- conn
+		case http.StateClosed, http.StateHijacked:
+			remove <- conn
+			timesLock.Lock()
+			delete(times, conn)
+			timesLock.Unlock()
+		}
+		if srv.ConnState != nil {
+			srv.ConnState(conn, state)
+		}
+	}
+
+	// Manage open connections
+	shutdown := make(chan chan struct{})
+	kill := make(chan struct{})
+	go srv.manageConnections(add, remove, shutdown, kill)
+
+	if srv.interrupt == nil {
+		srv.interrupt = make(chan os.Signal, 1)
+	}
+	// Set up the interrupt handler
+	if !srv.NoSignalHandling {
+		signal.Notify(srv.interrupt, syscall.SIGINT, syscall.SIGTERM)
+	}
+
+	go srv.handleInterrupt(listener)
+
+	// Serve with graceful listener.
+	// Execution blocks here until listener.Close() is called, above.
+	err := srv.Server.Serve(listener)
+
+	srv.shutdown(shutdown, kill)
+
+	return err
+}
+
+// Stop instructs the type to halt operations and close
+// the stop channel when it is finished.
+//
+// timeout is grace period for which to wait before shutting
+// down the server. The timeout value passed here will override the
+// timeout given when constructing the server, as this is an explicit
+// command to stop the server.
+func (srv *Server) Stop(timeout time.Duration) {
+	srv.Timeout = timeout
+	srv.interrupt <- syscall.SIGINT
+}
+
+// StopChan gets the stop channel which will block until
+// stopping has completed, at which point it is closed.
+// Callers should never close the stop channel.
+func (srv *Server) StopChan() <-chan struct{} {
+	srv.stopLock.Lock()
+	if srv.stopChan == nil {
+		srv.stopChan = make(chan struct{})
+	}
+	srv.stopLock.Unlock()
+	return srv.stopChan
+}
+
+func (srv *Server) manageConnections(add, remove chan net.Conn, shutdown chan chan struct{}, kill chan struct{}) {
+	{
+		var done chan struct{}
+		srv.connections = map[net.Conn]struct{}{}
+		for {
+			select {
+			case conn := <-add:
+				srv.connections[conn] = struct{}{}
+			case conn := <-remove:
+				delete(srv.connections, conn)
+				if done != nil && len(srv.connections) == 0 {
+					done <- struct{}{}
+					return
+				}
+			case done = <-shutdown:
+				if len(srv.connections) == 0 {
+					done <- struct{}{}
+					return
+				}
+			case <-kill:
+				for k := range srv.connections {
+					_ = k.Close() // nothing to do here if it errors
+				}
+				return
+			}
+		}
+	}
+}
+
+func (srv *Server) handleInterrupt(listener net.Listener) {
+	<-srv.interrupt
+	srv.SetKeepAlivesEnabled(false)
+	_ = listener.Close() // we are shutting down anyway. ignore error.
+
+	if srv.ShutdownInitiated != nil {
+		srv.ShutdownInitiated()
+	}
+
+	signal.Stop(srv.interrupt)
+	close(srv.interrupt)
+}
+
+func (srv *Server) shutdown(shutdown chan chan struct{}, kill chan struct{}) {
+	// Request done notification
+	done := make(chan struct{})
+	shutdown <- done
+
+	if srv.Timeout > 0 {
+		select {
+		case <-done:
+		case <-time.After(srv.Timeout):
+			close(kill)
+		}
+	} else {
+		<-done
+	}
+	// Close the stopChan to wake up any blocked goroutines.
+	srv.stopLock.Lock()
+	if srv.stopChan != nil {
+		close(srv.stopChan)
+	}
+	srv.stopLock.Unlock()
+}

--- a/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/graceful_test.go
+++ b/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/graceful_test.go
@@ -1,0 +1,333 @@
+package graceful
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"reflect"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+var killTime = 50 * time.Millisecond
+
+func runQuery(t *testing.T, expected int, shouldErr bool, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+	client := http.Client{}
+	r, err := client.Get("http://localhost:3000")
+	if shouldErr && err == nil {
+		t.Fatal("Expected an error but none was encountered.")
+	} else if shouldErr && err != nil {
+		if checkErr(t, err) {
+			return
+		}
+	}
+	if r != nil && r.StatusCode != expected {
+		t.Fatalf("Incorrect status code on response. Expected %d. Got %d", expected, r.StatusCode)
+	} else if r == nil {
+		t.Fatal("No response when a response was expected.")
+	}
+}
+
+func checkErr(t *testing.T, err error) bool {
+	if err.(*url.Error).Err == io.EOF {
+		return true
+	}
+	errno := err.(*url.Error).Err.(*net.OpError).Err.(syscall.Errno)
+	if errno == syscall.ECONNREFUSED {
+		return true
+	} else if err != nil {
+		t.Fatal("Error on Get:", err)
+	}
+	return false
+}
+
+func createListener(sleep time.Duration) (*http.Server, net.Listener, error) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		time.Sleep(sleep)
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	server := &http.Server{Addr: ":3000", Handler: mux}
+	l, err := net.Listen("tcp", ":3000")
+	return server, l, err
+}
+
+func runServer(timeout, sleep time.Duration, c chan os.Signal) error {
+	server, l, err := createListener(sleep)
+	if err != nil {
+		return err
+	}
+
+	srv := &Server{Timeout: timeout, Server: server, interrupt: c}
+	return srv.Serve(l)
+}
+
+func launchTestQueries(t *testing.T, wg *sync.WaitGroup, c chan os.Signal) {
+	for i := 0; i < 8; i++ {
+		go runQuery(t, http.StatusOK, false, wg)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	c <- os.Interrupt
+	time.Sleep(10 * time.Millisecond)
+
+	for i := 0; i < 8; i++ {
+		go runQuery(t, 0, true, wg)
+	}
+
+	wg.Done()
+}
+
+func TestGracefulRun(t *testing.T) {
+	c := make(chan os.Signal, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		runServer(killTime, killTime/2, c)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go launchTestQueries(t, &wg, c)
+	wg.Wait()
+}
+
+func TestGracefulRunTimesOut(t *testing.T) {
+	c := make(chan os.Signal, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		runServer(killTime, killTime*10, c)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		for i := 0; i < 8; i++ {
+			go runQuery(t, 0, true, &wg)
+		}
+		time.Sleep(10 * time.Millisecond)
+		c <- os.Interrupt
+		time.Sleep(10 * time.Millisecond)
+		for i := 0; i < 8; i++ {
+			go runQuery(t, 0, true, &wg)
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+}
+
+func TestGracefulRunDoesntTimeOut(t *testing.T) {
+	c := make(chan os.Signal, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		runServer(0, killTime*2, c)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go launchTestQueries(t, &wg, c)
+	wg.Wait()
+}
+
+func TestGracefulRunNoRequests(t *testing.T) {
+	c := make(chan os.Signal, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		runServer(0, killTime*2, c)
+		wg.Done()
+	}()
+
+	c <- os.Interrupt
+
+	wg.Wait()
+
+}
+
+func TestGracefulForwardsConnState(t *testing.T) {
+	c := make(chan os.Signal, 1)
+	states := make(map[http.ConnState]int)
+	var stateLock sync.Mutex
+
+	connState := func(conn net.Conn, state http.ConnState) {
+		stateLock.Lock()
+		states[state]++
+		stateLock.Unlock()
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	expected := map[http.ConnState]int{
+		http.StateNew:    8,
+		http.StateActive: 8,
+		http.StateClosed: 8,
+	}
+
+	go func() {
+		server, l, _ := createListener(killTime / 2)
+		srv := &Server{
+			ConnState: connState,
+			Timeout:   killTime,
+			Server:    server,
+			interrupt: c,
+		}
+		srv.Serve(l)
+
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go launchTestQueries(t, &wg, c)
+	wg.Wait()
+
+	stateLock.Lock()
+	if !reflect.DeepEqual(states, expected) {
+		t.Errorf("Incorrect connection state tracking.\n  actual: %v\nexpected: %v\n", states, expected)
+	}
+	stateLock.Unlock()
+}
+
+func TestGracefulExplicitStop(t *testing.T) {
+	server, l, err := createListener(1 * time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &Server{Timeout: killTime, Server: server}
+
+	go func() {
+		go srv.Serve(l)
+		time.Sleep(10 * time.Millisecond)
+		srv.Stop(killTime)
+	}()
+
+	// block on the stopChan until the server has shut down
+	select {
+	case <-srv.StopChan():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Timed out while waiting for explicit stop to complete")
+	}
+}
+
+func TestGracefulExplicitStopOverride(t *testing.T) {
+	server, l, err := createListener(1 * time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &Server{Timeout: killTime, Server: server}
+
+	go func() {
+		go srv.Serve(l)
+		time.Sleep(10 * time.Millisecond)
+		srv.Stop(killTime / 2)
+	}()
+
+	// block on the stopChan until the server has shut down
+	select {
+	case <-srv.StopChan():
+	case <-time.After(killTime):
+		t.Fatal("Timed out while waiting for explicit stop to complete")
+	}
+}
+
+func TestShutdownInitiatedCallback(t *testing.T) {
+	server, l, err := createListener(1 * time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	called := make(chan struct{})
+	cb := func() { close(called) }
+
+	srv := &Server{Server: server, ShutdownInitiated: cb}
+
+	go func() {
+		go srv.Serve(l)
+		time.Sleep(10 * time.Millisecond)
+		srv.Stop(killTime)
+	}()
+
+	select {
+	case <-called:
+	case <-time.After(killTime):
+		t.Fatal("Timed out while waiting for ShutdownInitiated callback to be called")
+	}
+}
+func hijackingListener(srv *Server) (*http.Server, net.Listener, error) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		conn, bufrw, err := rw.(http.Hijacker).Hijack()
+		if err != nil {
+			http.Error(rw, "webserver doesn't support hijacking", http.StatusInternalServerError)
+			return
+		}
+
+		defer conn.Close()
+
+		bufrw.WriteString("HTTP/1.1 200 OK\r\n\r\n")
+		bufrw.Flush()
+	})
+
+	server := &http.Server{Addr: ":3000", Handler: mux}
+	l, err := net.Listen("tcp", ":3000")
+	return server, l, err
+}
+
+func TestNotifyClosed(t *testing.T) {
+	c := make(chan os.Signal, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	srv := &Server{Timeout: killTime, interrupt: c}
+	server, l, err := hijackingListener(srv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv.Server = server
+
+	go func() {
+		srv.Serve(l)
+		wg.Done()
+	}()
+
+	for i := 0; i < 8; i++ {
+		runQuery(t, http.StatusOK, false, &wg)
+	}
+
+	srv.Stop(0)
+
+	// block on the stopChan until the server has shut down
+	select {
+	case <-srv.StopChan():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Timed out while waiting for explicit stop to complete")
+	}
+
+	if len(srv.connections) > 0 {
+		t.Fatal("hijacked connections should not be managed")
+	}
+
+}

--- a/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/tests/main.go
+++ b/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/tests/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/codegangsta/negroni"
+	"github.com/tylerb/graceful"
+)
+
+func main() {
+
+	var wg sync.WaitGroup
+
+	wg.Add(3)
+	go func() {
+		n := negroni.New()
+		fmt.Println("Launching server on :3000")
+		graceful.Run(":3000", 0, n)
+		fmt.Println("Terminated server on :3000")
+		wg.Done()
+	}()
+	go func() {
+		n := negroni.New()
+		fmt.Println("Launching server on :3001")
+		graceful.Run(":3001", 0, n)
+		fmt.Println("Terminated server on :3001")
+		wg.Done()
+	}()
+	go func() {
+		n := negroni.New()
+		fmt.Println("Launching server on :3002")
+		graceful.Run(":3002", 0, n)
+		fmt.Println("Terminated server on :3002")
+		wg.Done()
+	}()
+	fmt.Println("Press ctrl+c. All servers should terminate.")
+	wg.Wait()
+
+}

--- a/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/wercker.yml
+++ b/Godeps/_workspace/src/gopkg.in/tylerb/graceful.v1/wercker.yml
@@ -1,0 +1,1 @@
+box: wercker/golang

--- a/main.go
+++ b/main.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
+	"time"
 
 	"github.com/CenturyLinkLabs/imagelayers/api"
 	"github.com/CenturyLinkLabs/imagelayers/server"
 	"github.com/gorilla/mux"
+	"gopkg.in/tylerb/graceful.v1"
 )
 
 type layerServer struct {
@@ -20,12 +21,12 @@ func NewServer() *layerServer {
 	return new(layerServer)
 }
 
-func (s *layerServer) Start(port int) error {
+func (s *layerServer) Start(port int) {
 	router := s.createRouter()
 
 	log.Printf("Server starting on port %d", port)
 	portString := fmt.Sprintf(":%d", port)
-	return http.ListenAndServe(portString, router)
+	graceful.Run(portString, 10*time.Second, router)
 }
 
 func (s *layerServer) createRouter() server.Router {
@@ -59,8 +60,5 @@ func main() {
 	flag.Parse()
 
 	s := NewServer()
-	if err := s.Start(*port); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
+	s.Start(*port)
 }


### PR DESCRIPTION
Bringing in the "graceful" package to support graceful shutdown of the server. Now any SIGTERM/SIGINT signal will allow any active connections to complete before killing the server.